### PR TITLE
Use environment defaults for initial connection

### DIFF
--- a/app/PgAdmin4.py
+++ b/app/PgAdmin4.py
@@ -27,7 +27,7 @@ analyze_funcs = {500 + postgres_admin_queries.__dict__.keys().index(func): func
 
 
 
-default_connection_string = 'postgres://localhost:5432/'
+default_connection_string = 'postgres:///'
 
 class MainWindow(wx.Frame):
     id_buttons = {}


### PR DESCRIPTION
As far as I know, if you don't specify any options to the connection then libpq will pull defaults out of the environment, or as a last resort use it's built-in defaults. I think that's better than forcing localhost and 5432.

The localhost part is particularly annoying, since frequently IP connections require passwords but unix socket ones don't.

Note that I haven't tested this.
